### PR TITLE
Fix method declaration to be ruby-1.8-compatible

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -3,6 +3,7 @@ require 'net/https'
 require "rack-proxy"
 require "rack/reverse_proxy_matcher"
 require "rack/exception"
+require "rack/reverse_proxy/http_streaming_response"
 
 module Rack
   class ReverseProxy
@@ -72,7 +73,7 @@ module Rack
       target_response = HttpStreamingResponse.new(target_request, uri.host, uri.port)
 
       # pass the timeout configuration through
-      target_response.read_timeout = options[:timeout] if options[:timeout].to_i > 0
+      target_response.set_read_timeout(options[:timeout]) if options[:timeout].to_i > 0
 
       target_response.use_ssl = "https" == uri.scheme
 

--- a/lib/rack/reverse_proxy/http_streaming_response.rb
+++ b/lib/rack/reverse_proxy/http_streaming_response.rb
@@ -1,0 +1,7 @@
+module Rack
+  class HttpStreamingResponse
+    def set_read_timeout(value)
+      self.read_timeout = value
+    end
+  end
+end

--- a/lib/rack/reverse_proxy_matcher.rb
+++ b/lib/rack/reverse_proxy_matcher.rb
@@ -1,6 +1,6 @@
 module Rack
   class ReverseProxyMatcher
-    def initialize(matcher,url=nil,options)
+    def initialize(matcher, url=nil, options={})
       @default_url=url
       @url=url
       @options=options

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -324,9 +324,9 @@ RSpec.describe Rack::ReverseProxy do
 
       it "should proxy requests when a pattern is matched" do
         stub_request(:get, 'http://users-example.com/users?user=omer').to_return({:body => "User App"})
-        get '/test', user: "mark"
+        get '/test', :user => "mark"
         last_response.body.should == "Dummy App"
-        get '/users', user: 'omer'
+        get '/users', :user => 'omer'
         last_response.body.should == "User App"
       end
     end

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Rack::ReverseProxy do
 
       it "should make request with basic auth" do
         stub_request(:get, "http://example.com/test/slow")
-        Rack::HttpStreamingResponse.any_instance.should_receive(:read_timeout=).with(99)
+        Rack::HttpStreamingResponse.any_instance.should_receive(:set_read_timeout).with(99)
         get '/test/slow'
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe Rack::ReverseProxy do
 
       it "should make request with basic auth" do
         stub_request(:get, "http://example.com/test/slow")
-        Rack::HttpStreamingResponse.any_instance.should_not_receive(:read_timeout=)
+        Rack::HttpStreamingResponse.any_instance.should_not_receive(:set_read_timeout)
         get '/test/slow'
       end
     end


### PR DESCRIPTION
original PR here: https://github.com/jaswope/rack-reverse-proxy/pull/54