### PR TITLE
Omit port in Host header for default ports

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -47,7 +47,11 @@ module Rack
       target_request_headers = extract_http_request_headers(source_request.env)
 
       if options[:preserve_host]
-        target_request_headers['HOST'] = "#{uri.host}:#{uri.port}"
+        if uri.port == uri.default_port
+          target_request_headers['HOST'] = uri.host
+        else
+          target_request_headers['HOST'] = "#{uri.host}:#{uri.port}"
+        end
       end
 
       if options[:x_forwarded_host]


### PR DESCRIPTION
Setting default port in Host header break some web servers
like "Apache Coyote".

Most clients don't set this default port too:
* https://github.com/request/request/issues/515#issue-13221755
* https://github.com/ruby/ruby/blob/d46336e71731aa64d71d4573b2741b7de43ec340/lib/net/http/generic_request.rb#L18