### PR TITLE
Remove Rack::HttpStreamingResponse monkey-patch by upgrading rack-proxy

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -3,7 +3,6 @@ require 'net/https'
 require "rack-proxy"
 require "rack/reverse_proxy_matcher"
 require "rack/exception"
-require "rack/reverse_proxy/http_streaming_response"
 
 module Rack
   class ReverseProxy
@@ -77,7 +76,7 @@ module Rack
       target_response = HttpStreamingResponse.new(target_request, uri.host, uri.port)
 
       # pass the timeout configuration through
-      target_response.set_read_timeout(options[:timeout]) if options[:timeout].to_i > 0
+      target_response.read_timeout = options[:timeout] if options[:timeout].to_i > 0
 
       target_response.use_ssl = "https" == uri.scheme
 

--- a/lib/rack/reverse_proxy/http_streaming_response.rb
+++ b/lib/rack/reverse_proxy/http_streaming_response.rb
@@ -1,7 +1,0 @@
-module Rack
-  class HttpStreamingResponse
-    def set_read_timeout(value)
-      self.read_timeout = value
-    end
-  end
-end

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-bundler"
 
   s.add_dependency "rack", ">= 1.0.0"
-  s.add_dependency "rack-proxy", "~> 0.5"
+  s.add_dependency "rack-proxy", "~> 0.5", ">= 0.5.14"
 end

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Rack::ReverseProxy do
 
       it "should make request with basic auth" do
         stub_request(:get, "http://example.com/test/slow")
-        Rack::HttpStreamingResponse.any_instance.should_receive(:set_read_timeout).with(99)
+        Rack::HttpStreamingResponse.any_instance.should_receive(:read_timeout=).with(99)
         get '/test/slow'
       end
     end
@@ -159,7 +159,7 @@ RSpec.describe Rack::ReverseProxy do
 
       it "should make request with basic auth" do
         stub_request(:get, "http://example.com/test/slow")
-        Rack::HttpStreamingResponse.any_instance.should_not_receive(:set_read_timeout)
+        Rack::HttpStreamingResponse.any_instance.should_not_receive(:read_timeout=)
         get '/test/slow'
       end
     end

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe Rack::ReverseProxy do
     lambda { |env| [200, {}, ['Dummy App']] }
   end
 
+  let(:http_streaming_response) {
+    double(
+      "Rack::HttpStreamingResponse",
+      :use_ssl= => nil,
+      :verify_mode= => nil,
+      :headers => {},
+      :status => 200,
+      :body => "OK"
+    )
+  }
+
   describe "as middleware" do
     def app
       Rack::ReverseProxy.new(dummy_app) do
@@ -145,7 +156,8 @@ RSpec.describe Rack::ReverseProxy do
 
       it "should make request with basic auth" do
         stub_request(:get, "http://example.com/test/slow")
-        Rack::HttpStreamingResponse.any_instance.should_receive(:read_timeout=).with(99)
+        allow(Rack::HttpStreamingResponse).to receive(:new).and_return(http_streaming_response)
+        expect(http_streaming_response).to receive(:read_timeout=).with(99)
         get '/test/slow'
       end
     end
@@ -159,7 +171,8 @@ RSpec.describe Rack::ReverseProxy do
 
       it "should make request with basic auth" do
         stub_request(:get, "http://example.com/test/slow")
-        Rack::HttpStreamingResponse.any_instance.should_not_receive(:read_timeout=)
+        allow(Rack::HttpStreamingResponse).to receive(:new).and_return(http_streaming_response)
+        expect(http_streaming_response).not_to receive(:read_timeout=)
         get '/test/slow'
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,12 +13,12 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4.
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-    expectations.syntax = [:should]
+    expectations.syntax = [:should, :expect]
   end
   config.mock_with :rspec do |mocks|
     mocks.verify_doubled_constant_names = true
     mocks.verify_partial_doubles = true
-    mocks.syntax = [:should]
+    mocks.syntax = [:should, :expect]
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.


### PR DESCRIPTION
- In `v0.5.14`of rack-proxy `Rack::HttpStreamingResponse#read_timeout=` was added, see https://github.com/ncr/rack-proxy/commit/42e32e37bbbb9117cbd08e5a7ad8e41af8858973
- Easier to upgrade dependency (IMHO) than to maintain patching of external dependency