### PR TITLE
adds an option to set OpenSSL verify mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ run app
 * `:matching` is a global only option, if set to :first the first matched url will be requested (no ambigous error). Default: :all.
 * `:timeout` seconds to timout the requests
 * `:force_ssl` redirects to ssl version, if not already using it (requires `:replace_response_host`). Default: false.
+* `:verify_mode` the `OpenSSL::SSL` verify mode passed to Net::HTTP. Default: `OpenSSL::SSL::VERIFY_PEER`.
 
 ### Sample usage in a Ruby on Rails app
 

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -153,6 +153,7 @@ module RackReverseProxy
     def auto_use_ssl
       return unless "https" == uri.scheme
       target_response.use_ssl = true
+      target_response.verify_mode = options[:verify_mode] if options[:verify_mode]
     end
 
     def response_headers


### PR DESCRIPTION
With this PR it is possible to explicitly disable tls certificate verification in case your origin servers use invalid / self signed certificates.

Example usage:
```ruby
marathon_uri = URI.parse(ENV['MARATHON_URL'])
args_for_reverse_proxy = {}
args_for_reverse_proxy[:username] = marathon_uri.user if marathon_uri.user
args_for_reverse_proxy[:password] = marathon_uri.password if marathon_uri.password
args_for_reverse_proxy[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if ENV['MARATHON_INSECURE']

proxy = Rack::ReverseProxy.new do
  reverse_proxy /^\/proxy\/?(.*)$/, ENV['MARATHON_URL']+'/'+'$1', args_for_reverse_proxy
end
```
