### PR TITLE
Add openssl verify mode option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,22 +2,17 @@ source "https://rubygems.org"
 
 gemspec
 
-RUBOCOP_PLATFORMS = [:ruby_20, :ruby_21, :ruby_22]
-
 ruby_version = RUBY_VERSION.to_f
-if ruby_version < 2.0  # 1.9.3 and 1.8.7
-  RUBOCOP_PLATFORMS = [:ruby_20, :ruby_21]
-end
+rubocop_platform = [:ruby_20, :ruby_21, :ruby_22]
+rubocop_platform = [:ruby_20, :ruby_21] if ruby_version < 2.0
 
 group :test do
   gem "rspec"
   gem "rack-test"
   gem "webmock"
-  gem "rubocop", :platform => RUBOCOP_PLATFORMS
+  gem "rubocop", :platform => rubocop_platform
 
-  if ruby_version < 1.9  # 1.8.7
-    gem "addressable", "< 2.4"
-  end
+  gem "addressable", "< 2.4" if ruby_version < 1.9
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,20 @@ source "https://rubygems.org"
 
 gemspec
 
+RUBOCOP_PLATFORMS = [:ruby_20, :ruby_21, :ruby_22]
+
+ruby_version = RUBY_VERSION.to_f
+if ruby_version < 2.0  # 1.9.3 and 1.8.7
+  RUBOCOP_PLATFORMS = [:ruby_20, :ruby_21]
+end
+
 group :test do
   gem "rspec"
   gem "rack-test"
   gem "webmock"
-  gem "rubocop", :platform => [:ruby_20, :ruby_21, :ruby_22]
+  gem "rubocop", :platform => RUBOCOP_PLATFORMS
 
-  if RUBY_VERSION.to_f < 1.9
+  if ruby_version < 1.9  # 1.8.7
     gem "addressable", "< 2.4"
   end
 end

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ run app
 * `:matching` is a global only option, if set to :first the first matched url will be requested (no ambigous error). Default: :all.
 * `:timeout` seconds to timout the requests
 * `:force_ssl` redirects to ssl version, if not already using it (requires `:replace_response_host`). Default: false.
+* `:verify_mode` the `OpenSSL::SSL` verify mode passed to Net::HTTP. Default: `OpenSSL::SSL::VERIFY_PEER`.
 
 ### Sample usage in a Ruby on Rails app
 

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -32,7 +32,7 @@ module RackReverseProxy
 
     def reverse_proxy(rule, url = nil, opts = {})
       if rule.is_a?(String) && url.is_a?(String) && URI(url).class == URI::Generic
-        fail Errors::GenericURI.new, url
+        raise Errors::GenericURI.new, url
       end
       @rules << Rule.new(rule, url, opts)
     end

--- a/lib/rack_reverse_proxy/response_builder.rb
+++ b/lib/rack_reverse_proxy/response_builder.rb
@@ -1,8 +1,10 @@
 module RackReverseProxy
+  # ResponseBuilder knows target response building process
   class ResponseBuilder
     def initialize(target_request, uri, options)
-      @target_request, @uri, @options =
-        target_request, uri, options
+      @target_request = target_request
+      @uri = uri
+      @options = options
     end
 
     def fetch
@@ -42,7 +44,7 @@ module RackReverseProxy
     end
 
     def verify_mode?
-      !!options[:verify_mode]
+      options.key?(:verify_mode)
     end
 
     def target_response

--- a/lib/rack_reverse_proxy/response_builder.rb
+++ b/lib/rack_reverse_proxy/response_builder.rb
@@ -1,0 +1,58 @@
+module RackReverseProxy
+  class ResponseBuilder
+    def initialize(target_request, uri, options)
+      @target_request, @uri, @options =
+        target_request, uri, options
+    end
+
+    def fetch
+      setup_response
+      target_response
+    end
+
+    private
+
+    def setup_response
+      set_read_timeout
+      handle_https
+      handle_verify_mode
+    end
+
+    def set_read_timeout
+      return unless read_timeout?
+      target_response.read_timeout = options[:timeout]
+    end
+
+    def read_timeout?
+      options[:timeout].to_i > 0
+    end
+
+    def handle_https
+      return unless https?
+      target_response.use_ssl = true
+    end
+
+    def https?
+      "https" == uri.scheme
+    end
+
+    def handle_verify_mode
+      return unless verify_mode?
+      target_response.verify_mode = options[:verify_mode]
+    end
+
+    def verify_mode?
+      !!options[:verify_mode]
+    end
+
+    def target_response
+      @_target_response ||= Rack::HttpStreamingResponse.new(
+        target_request,
+        uri.host,
+        uri.port
+      )
+    end
+
+    attr_reader :target_request, :uri, :options
+  end
+end

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -136,9 +136,11 @@ module RackReverseProxy
     end
 
     def target_response
-      @_target_response ||= response_builder_klass
-        .new(target_request, uri, options)
-        .fetch
+      @_target_response ||= response_builder_klass.new(
+        target_request,
+        uri,
+        options
+      ).fetch
     end
 
     def response_headers

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -152,6 +152,7 @@ module RackReverseProxy
     def auto_use_ssl
       return unless "https" == uri.scheme
       target_response.use_ssl = true
+      target_response.verify_mode = options[:verify_mode] if options[:verify_mode]
     end
 
     def response_headers

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -7,7 +7,7 @@ module RackReverseProxy
   # RoundTrip represents one request-response made by rack-reverse-proxy
   # middleware.
   class RoundTrip
-    def initialize(app, env, global_options, rules, response_builder_klass=ResponseBuilder)
+    def initialize(app, env, global_options, rules, response_builder_klass = ResponseBuilder)
       @app = app
       @env = env
       @global_options = global_options
@@ -92,7 +92,7 @@ module RackReverseProxy
     def set_forwarded_host
       return unless options[:x_forwarded_host]
       target_request_headers["X-Forwarded-Host"] = source_request.host
-      target_request_headers["X-Forwarded-Port"] = "#{source_request.port}"
+      target_request_headers["X-Forwarded-Port"] = source_request.port.to_s
     end
 
     def initialize_http_header
@@ -253,7 +253,7 @@ module RackReverseProxy
 
     def non_ambiguous_match
       return unless ambiguous_match?
-      fail Errors::AmbiguousMatch.new(path, matches)
+      raise Errors::AmbiguousMatch.new(path, matches)
     end
 
     def ambiguous_match?

--- a/lib/rack_reverse_proxy/rule.rb
+++ b/lib/rack_reverse_proxy/rule.rb
@@ -48,7 +48,7 @@ module RackReverseProxy
       return /^#{spec}/ if spec.is_a?(String)
       return spec if spec.respond_to?(:match)
       return spec if spec.respond_to?(:call)
-      fail ArgumentError, "Invalid Rule for reverse_proxy"
+      raise ArgumentError, "Invalid Rule for reverse_proxy"
     end
 
     # Candidate represents a request being matched

--- a/lib/rack_reverse_proxy/version.rb
+++ b/lib/rack_reverse_proxy/version.rb
@@ -1,4 +1,4 @@
 #:nodoc:
 module RackReverseProxy
-  VERSION = "0.9.1"
+  VERSION = "0.9.1".freeze
 end

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe Rack::ReverseProxy do
       #:nodoc:
       class Matcher
         def self.match(path)
-          return unless path.match(%r{^/(test|users)})
+          return unless path =~ %r{^/(test|users)}
           Matcher.new
         end
 
@@ -504,7 +504,7 @@ RSpec.describe Rack::ReverseProxy do
         end
 
         def self.match(path, _headers, rackreq)
-          return nil unless path.match(%r{^/(test|users)})
+          return nil unless path =~ %r{^/(test|users)}
           RequestMatcher.new(rackreq)
         end
 

--- a/spec/rack_reverse_proxy/response_builder_spec.rb
+++ b/spec/rack_reverse_proxy/response_builder_spec.rb
@@ -4,7 +4,7 @@ module RackReverseProxy
   RSpec.describe ResponseBuilder do
     let(:options) { {} }
     let(:uri_opt) { { :uri => "http://example.org/hello/world" } }
-    let(:request) { OpenStruct.new }
+    let(:request) { double("Request") }
 
     subject(:response) do
       ResponseBuilder.new(

--- a/spec/rack_reverse_proxy/response_builder_spec.rb
+++ b/spec/rack_reverse_proxy/response_builder_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+module RackReverseProxy
+  RSpec.describe ResponseBuilder do
+    let(:options) { {} }
+    let(:uri_opt) { { :uri => "http://example.org/hello/world" } }
+    let(:request) { OpenStruct.new }
+
+    subject(:response) do
+      ResponseBuilder.new(
+        request,
+        URI(uri_opt[:uri]),
+        options
+      ).fetch
+    end
+
+    it "is a Rack::HttpStreamingResponse" do
+      expect(response).to be_a(Rack::HttpStreamingResponse)
+    end
+
+    it "sets up read timeout" do
+      options[:timeout] = 42
+      expect(response.read_timeout).to eq(42)
+    end
+
+    it "sets up ssl when needed" do
+      uri_opt[:uri] = "https://example.org/hello/world"
+      expect(response.use_ssl).to eq(true)
+    end
+
+    it "it is possible to change ssl verify mode" do
+      mode = OpenSSL::SSL::VERIFY_NONE
+      options[:verify_mode] = mode
+      expect(response.verify_mode).to eq(mode)
+    end
+  end
+end


### PR DESCRIPTION
This PR:
- extracts response building process to a class of its own
- unit-tests response building process
- adds option to set OpenSSL verify mode (credit: @MrMarvin)

Closes #24 