### PR TITLE
Added X-Forwarded-For header in RoundTrip::set_forwarded_host()

### DIFF
--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -13,7 +13,7 @@ module RackReverseProxy
       @rules = []
       @global_options = {
         :preserve_host => true,
-        :x_forwarded_host => true,
+        :x_forwarded_headers => true,
         :matching => :all,
         :replace_response_host => false
       }

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -89,7 +89,7 @@ module RackReverseProxy
       "#{uri.host}:#{uri.port}"
     end
 
-    def set_forwarded_host
+    def set_forwarded_headers
       return unless options[:x_forwarded_host]
       target_request_headers["X-Forwarded-Host"] = source_request.host
       target_request_headers["X-Forwarded-Port"] = source_request.port.to_s
@@ -178,7 +178,7 @@ module RackReverseProxy
 
     def setup_request
       preserve_host
-      set_forwarded_host
+      set_forwarded_headers
       initialize_http_header
       set_basic_auth
       setup_body

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -90,7 +90,7 @@ module RackReverseProxy
     end
 
     def set_forwarded_headers
-      return unless options[:x_forwarded_host]
+      return unless options[:x_forwarded_headers]
       target_request_headers["X-Forwarded-Host"] = source_request.host
       target_request_headers["X-Forwarded-Port"] = source_request.port.to_s
     end

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -176,10 +176,10 @@ RSpec.describe Rack::ReverseProxy do
       end
     end
 
-    describe "with x_forwarded_host turned off" do
+    describe "with x_forwarded_headers turned off" do
       def app
         Rack::ReverseProxy.new(dummy_app) do
-          reverse_proxy_options :x_forwarded_host => false
+          reverse_proxy_options :x_forwarded_headers => false
           reverse_proxy "/test", "http://example.com/"
         end
       end

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe Rack::ReverseProxy do
       ).to have_been_made
     end
 
+    it "sets the X-Forwarded-Port header to the proxying port by default" do
+      stub_request(:any, "example.com/test/stuff")
+      get "/test/stuff"
+      expect(
+        a_request(:get, "http://example.com/test/stuff").with(
+          :headers => { "X-Forwarded-Port" => "80" }
+        )
+      ).to have_been_made
+    end
+
     it "does not produce headers with a Status key" do
       stub_request(:get, "http://example.com/2test").to_return(
         :status => 301, :headers => { :status => "301 Moved Permanently" }
@@ -190,6 +200,17 @@ RSpec.describe Rack::ReverseProxy do
         expect(
           a_request(:get, "http://example.com/test/stuff").with(
             :headers => { "X-Forwarded-Host" => "example.org" }
+          )
+        ).not_to have_been_made
+        expect(a_request(:get, "http://example.com/test/stuff")).to have_been_made
+      end
+
+      it "does not set the X-Forwarded-Port header to the proxying port" do
+        stub_request(:any, "example.com/test/stuff")
+        get "/test/stuff"
+        expect(
+          a_request(:get, "http://example.com/test/stuff").with(
+            :headers => { "X-Forwarded-Port" => "80" }
           )
         ).not_to have_been_made
         expect(a_request(:get, "http://example.com/test/stuff")).to have_been_made


### PR DESCRIPTION
Since X-Forwarded-Port is part of set_forwarded_host() rather than in its own method, I did the same for X-Forwarded-For.

It would be better to rename set_forwarded_host() to set_forwarded_headers() as well as the corresponding option (:x_forwarded_host to :x_forwarded_headers)

@waterlink When could you create a new release with this change? Also, what do you think about the refactoring proposal above?