### PR TITLE
Remove Accept-Encoding header

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ run app
 * `:force_ssl` redirects to ssl version, if not already using it (requires `:replace_response_host`). Default: false.
 * `:verify_mode` the `OpenSSL::SSL` verify mode passed to Net::HTTP. Default: `OpenSSL::SSL::VERIFY_PEER`.
 * `:x_forwarded_headers` sets up proper `X-Forwarded-*` headers. Default: true.
+* `:preserve_encoding` Set to true to pass Accept-Encoding header to proxy server. Default: false.
 
 ### Sample usage in a Ruby on Rails app
 

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -13,6 +13,7 @@ module RackReverseProxy
       @rules = []
       @global_options = {
         :preserve_host => true,
+        :preserve_encoding => false,
         :x_forwarded_headers => true,
         :matching => :all,
         :replace_response_host => false

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -84,6 +84,11 @@ module RackReverseProxy
       target_request_headers["HOST"] = host_header
     end
 
+    def preserve_encoding
+      return if options[:preserve_encoding]
+      target_request_headers.delete("Accept-Encoding")
+    end
+
     def host_header
       return uri.host if uri.port == uri.default_port
       "#{uri.host}:#{uri.port}"
@@ -178,6 +183,7 @@ module RackReverseProxy
 
     def setup_request
       preserve_host
+      preserve_encoding
       set_forwarded_headers
       initialize_http_header
       set_basic_auth


### PR DESCRIPTION
We are using Heroku and we had similar issue mentioned here: https://github.com/waterlink/rack-reverse-proxy/issues/12. 

The problem was that compression was applied twice: first time on proxied response and second time on original response. So I see two possible solutions: either decompress proxied response or do not send "Accept-Encoding" to proxy server. I used second solution, what do you think?

Closes #12