### PR TITLE
Rescue from connection refused errors and return the appropriate status code

### DIFF
--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -166,6 +166,9 @@ module RackReverseProxy
           format_headers(target_response.headers)
         )
       )
+    rescue Errno::ECONNREFUSED => e
+      @_target_response = Struct.new(:status, :body).new(502, [])
+      {}
     end
 
     def replace_location_header


### PR DESCRIPTION
When the app that is being proxied is not running, the code currently returns an exception. This prevents the exception and returns the appropriate status code.