### PR TITLE
new stripped_headers option & retire preserve_encoding option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.0.0 (UNRELEASED)
 
 - Breaking Change: Never modify Location headers that are only paths without hosts. [John Bachir](https://github.com/jjb) [#46](https://github.com/waterlink/rack-reverse-proxy/pull/46)
+- Breaking Change: Previously, the Accept-Encoding header was stripped by default, unless the
+  `preserve_encoding` option was set to true. Now, no headers are stripped by default, and an array
+  of headers that should be stripped can be specified with the `stripped_headers` option.
 - Bugfix: Fix rack response body for https redirects [John Bachir](https://github.com/jjb) [#43](https://github.com/waterlink/rack-reverse-proxy/pull/43)
 
 ## 0.12.0

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Right now if more than one rule matches any given route, it throws an exception 
 * `:force_ssl` redirects to ssl version, if not already using it (requires `:replace_response_host`). Default: false.
 * `:verify_mode` the `OpenSSL::SSL` verify mode passed to Net::HTTP. Default: `OpenSSL::SSL::VERIFY_PEER`.
 * `:x_forwarded_headers` sets up proper `X-Forwarded-*` headers. Default: true.
-* `:preserve_encoding` Set to true to pass Accept-Encoding header to proxy server. Default: false.
+* `:stripped_headers` Array of headers that should be stripped before forwarding reqeust. Default: nil.
+  e.g. `stripped_headers: ["Accept-Encoding", "Foo-Bar"]`
 
 ## Note on Patches/Pull Requests
 * Fork the project.

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -13,7 +13,7 @@ module RackReverseProxy
       @rules = []
       @global_options = {
         :preserve_host => true,
-        :preserve_encoding => false,
+        :stripped_headers => nil,
         :x_forwarded_headers => true,
         :matching => :all,
         :replace_response_host => false

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -84,9 +84,11 @@ module RackReverseProxy
       target_request_headers["HOST"] = host_header
     end
 
-    def preserve_encoding
-      return if options[:preserve_encoding]
-      target_request_headers.delete("Accept-Encoding")
+    def strip_headers
+      return unless options[:stripped_headers]
+      options[:stripped_headers].each do |header|
+        target_request_headers.delete(header)
+      end
     end
 
     def host_header
@@ -184,7 +186,7 @@ module RackReverseProxy
 
     def setup_request
       preserve_host
-      preserve_encoding
+      strip_headers
       set_forwarded_headers
       initialize_http_header
       set_basic_auth


### PR DESCRIPTION
This was the cause of #44... 🤦‍♂️ 

I think this is
* a much more rational default
* a much more useful and flexible option

The stripped Accept-Encoding header was a result of #27. But I think that the problems the author was experiencing in #27 was caused by the middleware not being in the ideal place. This is addressed with a new recommendation in #49.

I used rspec `context` to structure the tests a bit more DRYly, but the strange behavior with the variable access in the `app` method resulted. I'm not familiar with this `def app` convention and couldn't find anything else in the code to figure out when/how it was being used. It also doesn't make an appearance in the webmock readme, so I think I must be missing something.

let me know what you think of the new behavior and of the test style.