### PR TITLE
Allow to set extra request headers

### DIFF
--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -90,6 +90,13 @@ module RackReverseProxy
         target_request_headers.delete(header)
       end
     end
+    
+    def extra_headers
+      return unless options[:extra_headers]
+      options[:extra_headers].each do |k,v|
+        target_request_headers[k.to_s] = v
+      end
+    end
 
     def host_header
       return uri.host if uri.port == uri.default_port
@@ -187,6 +194,7 @@ module RackReverseProxy
     def setup_request
       preserve_host
       strip_headers
+      extra_headers
       set_forwarded_headers
       initialize_http_header
       set_basic_auth

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -276,6 +276,30 @@ RSpec.describe Rack::ReverseProxy do
         end
       end
     end
+    
+    context "extra_headers option" do
+      subject do
+        stub_request(:any, "http://example.com/test")
+        get "/test", {}, "HTTP_ACCEPT_ENCODING" => "gzip, deflate""
+      end
+
+      describe "with extra_headers set" do
+        def app
+          Rack::ReverseProxy.new(dummy_app) do
+            reverse_proxy "/test", "http://example.com/", extra_headers: {"HTTP_FOO_BAR" => "baz"}
+          end
+        end
+
+        it "adds extra headers to the request headers" do
+          subject
+          expect(
+            a_request(:get, "http://example.com/test").with(
+              :headers => { "Accept-Encoding" => "gzip, deflate", "Foo-Bar" => "baz" }
+            )
+          ).to have_been_made
+        end
+      end
+    end
 
     describe "with x_forwarded_headers turned off" do
       def app


### PR DESCRIPTION
In my use case, I need to set custom request headers while proxying the request. I've added `extra_headers` option that accepts a hash of headers to be added to request headers.

So the following is possible:
```
reverse_proxy "/test", "http://example.com/", extra_headers: {"HTTP_FOO_BAR" => "baz"}
```

If you find it useful, I will add description to docs, before it will be merged.
