### PR TITLE
Rescue origin errors

### DIFF
--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -169,6 +169,7 @@ module RackReverseProxy
         )
       )
     rescue Errno::ECONNREFUSED => e
+      puts "rack-reverse-proxy rescued error from origin: #{e.class.name}: #{e.message}"
       @_target_response = Struct.new(:status, :body).new(502, [])
       {}
     end

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -168,6 +168,9 @@ module RackReverseProxy
           format_headers(target_response.headers)
         )
       )
+    rescue Errno::ECONNREFUSED => e
+      @_target_response = Struct.new(:status, :body).new(502, [])
+      {}
     end
 
     def replace_location_header

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -162,13 +162,31 @@ module RackReverseProxy
       end
     end
 
+    NET_HTTP_EXCEPTIONS = [
+      IOError,
+      Errno::ECONNABORTED,
+      Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
+      Errno::EHOSTUNREACH,
+      Errno::EINVAL,
+      Errno::ENETUNREACH,
+      Errno::EPIPE,
+      Net::HTTPBadResponse,
+      Net::HTTPHeaderSyntaxError,
+      Net::ProtocolError,
+      SocketError,
+      Zlib::GzipFile::Error,
+    ]
+    NET_HTTP_EXCEPTIONS << OpenSSL::SSL::SSLError if defined?(OpenSSL)
+    NET_HTTP_EXCEPTIONS << Net::OpenTimeout if defined?(Net::OpenTimeout)
+
     def rack_response_headers
       Rack::Utils::HeaderHash.new(
         Rack::Proxy.normalize_headers(
           format_headers(target_response.headers)
         )
       )
-    rescue Errno::ECONNREFUSED => e
+    rescue *NET_HTTP_EXCEPTIONS => e
       puts "rack-reverse-proxy rescued error from origin: #{e.class.name}: #{e.message}"
       @_target_response = Struct.new(:status, :body).new(502, [])
       {}


### PR DESCRIPTION
building off of work from @andrewhavens in https://github.com/waterlink/rack-reverse-proxy/pull/42

perhaps the log message could be more accurate... "error when connecting to origin" or something