### PR TITLE
Add routing constraints

### DIFF
--- a/lib/rack_reverse_proxy/rule.rb
+++ b/lib/rack_reverse_proxy/rule.rb
@@ -207,8 +207,8 @@ module RackReverseProxy
         if constraint.blank?
           return true
         end
-
-        constraint.call(rackreq.env)
+        
+        constraint.call(rackreq)
       end
     end
   end

--- a/lib/rack_reverse_proxy/rule.rb
+++ b/lib/rack_reverse_proxy/rule.rb
@@ -132,7 +132,7 @@ module RackReverseProxy
         @rackreq = rackreq
 
         @headers = headers if options[:accept_headers]
-        @constraints = options[:constraints]
+        @constraint = options[:constraint]
         @spec_arity = spec.method(spec_match_method_name).arity
       end
 
@@ -165,7 +165,7 @@ module RackReverseProxy
 
       private
 
-      attr_reader :spec, :url, :path, :headers, :rackreq, :spec_arity, :has_custom_url, :constraints
+      attr_reader :spec, :url, :path, :headers, :rackreq, :spec_arity, :has_custom_url, :constraint
 
       def found
         @_found ||= find_matches
@@ -204,11 +204,11 @@ module RackReverseProxy
       end
 
       def apply_constraints!
-        if constraints.blank?
+        if constraint.blank?
           return true
         end
 
-        constraints.call(rackreq.env)
+        constraint.call(rackreq.env)
       end
     end
   end


### PR DESCRIPTION
Related to https://github.com/waterlink/rack-reverse-proxy/issues/29.

We had a case where we needed to proxy requests for the root-level domain, but didn't want to proxy requests for any subdomains. This is the type of scenario this PR looks to address.

To use this, simply pass a lambda to a `constraint` option on `reverse_proxy`.  This lambda should return a boolean, but any truthy value will work:

```ruby
reverse_proxy '/test', 'https://example.com', constraint: ->(req) { req.host === 'root-level-domain.com' }
```

As you can see, there is access to the rack request object within the constraint.

Usage of constraints is entirely optional and should not pose any issues to backward compatibility.