### PR TITLE
Update code to be compatibile with Rack v3.1+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ end
 
 group :development, :test do
   gem "simplecov"
+  gem "debug", platforms: %i[mri mingw x64_mingw]
 end

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -17,7 +17,7 @@ module RackReverseProxy
     }
 
     def initialize(app = nil, &b)
-      @app = app || lambda { |_| [404, [], []] }
+      @app = app || lambda { |_| [404, {}, []] }
       @rules = []
       @global_options = DEFAULT_OPTIONS
       instance_eval(&b) if block_given?

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -152,7 +152,7 @@ module RackReverseProxy
     end
 
     def response_headers
-      @_response_headers ||= build_response_headers
+      @_response_headers ||= build_response_headers.transform_keys(&:downcase)
     end
 
     def build_response_headers
@@ -163,7 +163,7 @@ module RackReverseProxy
     end
 
     def rack_response_headers
-      Rack::Utils::HeaderHash.new(
+      Rack::Headers.new.merge(
         Rack::Proxy.normalize_headers(
           format_headers(target_response.headers)
         )
@@ -173,15 +173,15 @@ module RackReverseProxy
     def replace_location_header
       return unless need_replace_location?
       rewrite_uri(response_location, source_request)
-      response_headers["Location"] = response_location.to_s
+      response_headers["location"] = response_location.to_s
     end
 
     def response_location
-      @_response_location ||= URI(response_headers["Location"])
+      @_response_location ||= URI(response_headers["location"] || uri)
     end
 
     def need_replace_location?
-      response_headers["Location"] && options[:replace_response_host] && response_location.host
+      response_headers["location"] && options[:replace_response_host] && response_location.host
     end
 
     def setup_request

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -36,9 +36,9 @@ eos
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rack", ">= 1.0.0"
-  spec.add_dependency "rack-proxy", "~> 0.6", ">= 0.6.1"
+  spec.add_dependency "rack-proxy", "~> 0.7", ">= 0.7.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.3"
+  spec.add_development_dependency "bundler", "~> 2.5"
+  spec.add_development_dependency "rake", "~> 13.2"
 end
 # rubocop:enable

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Rack::ReverseProxy do
     )
   end
 
-  describe "global options", focus: true do
+  describe "global options" do
     it "starts with default global options" do
       m = Rack::ReverseProxy.new(dummy_app) do
         reverse_proxy "/test", "http://example.com/"
@@ -73,10 +73,10 @@ RSpec.describe Rack::ReverseProxy do
       expect(last_response.body).to eq("Proxied App")
     end
 
-    it "produces a response header of type HeaderHash" do
+    it "produces a response header of type Headers" do
       stub_request(:get, "http://example.com/test")
       get "/test"
-      expect(last_response.headers).to be_an_instance_of(Rack::Utils::HeaderHash)
+      expect(last_response.headers).to be_an_instance_of(Rack::Headers)
     end
 
     it "parses the headers as a Hash with values of type String" do
@@ -154,7 +154,7 @@ RSpec.describe Rack::ReverseProxy do
       expect(headers["Status"]).to be_nil
     end
 
-    it "formats the headers correctly to avoid duplicates" do
+    it "compares keys case-insensitive" do
       stub_request(:get, "http://example.com/2test").to_return(
         :headers => { :date => "Wed, 22 Jul 2015 11:27:21 GMT" }
       )
@@ -163,7 +163,7 @@ RSpec.describe Rack::ReverseProxy do
 
       headers = last_response.headers.to_hash
       expect(headers["Date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
-      expect(headers["date"]).to be_nil
+      expect(headers["date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
     end
 
     it "formats the headers with dashes correctly" do
@@ -175,8 +175,7 @@ RSpec.describe Rack::ReverseProxy do
       get "/2test"
 
       headers = last_response.headers.to_hash
-      expect(headers["X-Additional-Info"]).to eq("something")
-      expect(headers["x-additional-info"]).to be_nil
+      expect(headers["x-additional-info"]).to eq("something")
     end
 
     it "the response header includes content-length" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 require "simplecov"
 SimpleCov.start
 
+require "debug"
 require "rack/reverse_proxy"
 require "rack/test"
 require "webmock/rspec"


### PR DESCRIPTION
- Removes usage of deprecated class `Rack::Utils::HeaderHash`.
- Updates dependencies to be current, e.g. Rake v13.2 and Rack 3.1+
- Removes `focus` from tests so all tests run
- Fixes and updates all tests