### PR TITLE
feat: rack 2 and 3 compat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        os: ["ubuntu-latest","windows-latest","macos-latest"]
+        rack_version: ["2", "3"]
+    runs-on: ${{ matrix.os }}
+    env:
+      RACK_VERSION: ${{ matrix.rack_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+      - run: "bundle install"
+      - run: "bundle exec rake"

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ end
 
 group :development, :test do
   gem "simplecov"
+  gem "debug", platforms: %i[mri mingw x64_mingw]
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,4 @@ end
 
 group :development, :test do
   gem "simplecov"
-  gem "debug", platforms: %i[mri mingw x64_mingw]
 end

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -17,7 +17,7 @@ module RackReverseProxy
     }
 
     def initialize(app = nil, &b)
-      @app = app || lambda { |_| [404, [], []] }
+      @app = app || lambda { |_| [404, {}, []] }
       @rules = []
       @global_options = DEFAULT_OPTIONS
       instance_eval(&b) if block_given?

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -17,8 +17,8 @@ module RackReverseProxy
     }
 
     def initialize(app = nil, &b)
-      @app = app || lambda { |_| [404, {}, []] }
-      @rules = []
+      @app = app || lambda { |_| [404, ENV['RACK_VERSION'] == '2' ? [] : {}, []] }
+              @rules = []
       @global_options = DEFAULT_OPTIONS
       instance_eval(&b) if block_given?
     end

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -18,7 +18,7 @@ module RackReverseProxy
 
     def initialize(app = nil, &b)
       @app = app || lambda { |_| [404, ENV['RACK_VERSION'] == '2' ? [] : {}, []] }
-              @rules = []
+      @rules = []
       @global_options = DEFAULT_OPTIONS
       instance_eval(&b) if block_given?
     end

--- a/lib/rack_reverse_proxy/middleware.rb
+++ b/lib/rack_reverse_proxy/middleware.rb
@@ -17,7 +17,7 @@ module RackReverseProxy
     }
 
     def initialize(app = nil, &b)
-      @app = app || lambda { |_| [404, ENV['RACK_VERSION'] == '2' ? [] : {}, []] }
+      @app = app || lambda { |_| [404, rack_version_less_than_three ? [] : {}, []] }
       @rules = []
       @global_options = DEFAULT_OPTIONS
       instance_eval(&b) if block_given?
@@ -28,6 +28,10 @@ module RackReverseProxy
     end
 
     private
+
+    def rack_version_less_than_three
+      Rack.release.split('.').first.to_i < 3
+    end
 
     def reverse_proxy_options(options)
       @global_options = @global_options.merge(options)

--- a/lib/rack_reverse_proxy/roundtrip.rb
+++ b/lib/rack_reverse_proxy/roundtrip.rb
@@ -152,7 +152,7 @@ module RackReverseProxy
     end
 
     def response_headers
-      @_response_headers ||= build_response_headers
+      @_response_headers ||= build_response_headers.transform_keys(&:downcase)
     end
 
     def build_response_headers
@@ -163,7 +163,7 @@ module RackReverseProxy
     end
 
     def rack_response_headers
-      Rack::Utils::HeaderHash.new(
+      Rack::Headers.new.merge(
         Rack::Proxy.normalize_headers(
           format_headers(target_response.headers)
         )
@@ -173,15 +173,15 @@ module RackReverseProxy
     def replace_location_header
       return unless need_replace_location?
       rewrite_uri(response_location, source_request)
-      response_headers["Location"] = response_location.to_s
+      response_headers["location"] = response_location.to_s
     end
 
     def response_location
-      @_response_location ||= URI(response_headers["Location"])
+      @_response_location ||= URI(response_headers["location"] || uri)
     end
 
     def need_replace_location?
-      response_headers["Location"] && options[:replace_response_host] && response_location.host
+      response_headers["location"] && options[:replace_response_host] && response_location.host
     end
 
     def setup_request

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -36,9 +36,9 @@ eos
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rack", ">= 1.0.0"
-  spec.add_dependency "rack-proxy", "~> 0.6", ">= 0.6.1"
+  spec.add_dependency "rack-proxy", "~> 0.7", ">= 0.7.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.3"
+  spec.add_development_dependency "bundler", "~> 2.5"
+  spec.add_development_dependency "rake", "~> 13.2"
 end
 # rubocop:enable

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -35,7 +35,7 @@ eos
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  if ENV['RACK_VERSION'] == '2'
+  if ENV["RACK_VERSION"] = "2"
     spec.add_dependency 'rack', ">= 1.0.0", '< 3.0'
   else
     spec.add_dependency 'rack', '>= 3.0', '< 4.0'

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -35,10 +35,15 @@ eos
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rack", ">= 1.0.0"
-  spec.add_dependency "rack-proxy", "~> 0.7", ">= 0.7.0"
+  if ENV['RACK_VERSION'] == '2'
+    spec.add_dependency 'rack', ">= 1.0.0", '< 3.0'
+  else
+    spec.add_dependency 'rack', '>= 3.0', '< 4.0'
+    spec.add_dependency 'rackup', '~> 2.0'
+  end
+  spec.add_dependency "rack-proxy", "~> 0.6", ">= 0.6.1"
 
-  spec.add_development_dependency "bundler", "~> 2.5"
-  spec.add_development_dependency "rake", "~> 13.2"
+  spec.add_development_dependency "bundler", ">= 1.7", "< 3.0"
+  spec.add_development_dependency "rake", ">= 10.3"
 end
 # rubocop:enable

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -35,7 +35,7 @@ eos
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  if ENV["RACK_VERSION"] = "2"
+  if ENV['RACK_VERSION'] == '2'
     spec.add_dependency 'rack', ">= 1.0.0", '< 3.0'
   else
     spec.add_dependency 'rack', '>= 3.0', '< 4.0'

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Rack::ReverseProxy do
     )
   end
 
-  describe "global options", focus: true do
+  describe "global options" do
     it "starts with default global options" do
       m = Rack::ReverseProxy.new(dummy_app) do
         reverse_proxy "/test", "http://example.com/"
@@ -73,10 +73,10 @@ RSpec.describe Rack::ReverseProxy do
       expect(last_response.body).to eq("Proxied App")
     end
 
-    it "produces a response header of type HeaderHash" do
+    it "produces a response header of type Headers" do
       stub_request(:get, "http://example.com/test")
       get "/test"
-      expect(last_response.headers).to be_an_instance_of(Rack::Utils::HeaderHash)
+      expect(last_response.headers).to be_an_instance_of(Rack::Headers)
     end
 
     it "parses the headers as a Hash with values of type String" do
@@ -154,7 +154,7 @@ RSpec.describe Rack::ReverseProxy do
       expect(headers["Status"]).to be_nil
     end
 
-    it "formats the headers correctly to avoid duplicates" do
+    it "compares keys case-insensitive" do
       stub_request(:get, "http://example.com/2test").to_return(
         :headers => { :date => "Wed, 22 Jul 2015 11:27:21 GMT" }
       )
@@ -163,7 +163,7 @@ RSpec.describe Rack::ReverseProxy do
 
       headers = last_response.headers.to_hash
       expect(headers["Date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
-      expect(headers["date"]).to be_nil
+      expect(headers["date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
     end
 
     it "formats the headers with dashes correctly" do
@@ -175,8 +175,7 @@ RSpec.describe Rack::ReverseProxy do
       get "/2test"
 
       headers = last_response.headers.to_hash
-      expect(headers["X-Additional-Info"]).to eq("something")
-      expect(headers["x-additional-info"]).to be_nil
+      expect(headers["x-additional-info"]).to eq("something")
     end
 
     it "the response header includes content-length" do

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Rack::ReverseProxy do
     it "produces a response header of type Headers" do
       stub_request(:get, "http://example.com/test")
       get "/test"
-      expected_class = ENV['RACK_VERSION'] == "2" ? Rack::Utils::HeaderHash : Rack::Headers
+      expected_class = rack_version_less_than_three ? Rack::Utils::HeaderHash : Rack::Headers
       expect(last_response.headers).to be_an_instance_of(expected_class)
     end
 
@@ -164,11 +164,7 @@ RSpec.describe Rack::ReverseProxy do
 
       headers = last_response.headers.to_hash
       expect(headers["Date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
-      if ENV['RACK_VERSION'] == "2"
-        expect(headers["date"]).to be_nil
-      else
-        expect(headers["date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
-      end
+      expect(headers["date"]).to rack_version_less_than_three ? be_nil : eq("Wed, 22 Jul 2015 11:27:21 GMT")
     end
 
     it "formats the headers with dashes correctly" do
@@ -180,11 +176,7 @@ RSpec.describe Rack::ReverseProxy do
       get "/2test"
 
       headers = last_response.headers.to_hash
-      if ENV['RACK_VERSION'] == "2"
-        expect(headers["x-additional-info"]).to be_nil
-      else
-        expect(headers["x-additional-info"]).to eq("something")
-      end
+        expect(headers["x-additional-info"]).to eq(rack_version_less_than_three ? nil : "something")
     end
 
     it "the response header includes content-length" do
@@ -767,7 +759,7 @@ RSpec.describe Rack::ReverseProxy do
     end
   end
 
-  describe "as a rack app", skip: ENV['RACK_VERSION'] == "2" do
+  describe "as a rack app", skip: rack_version_less_than_three do
     it "responds with 404 when the path is not matched" do
       get "/"
       expect(last_response).to be_not_found

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe Rack::ReverseProxy do
     it "produces a response header of type Headers" do
       stub_request(:get, "http://example.com/test")
       get "/test"
-      expect(last_response.headers).to be_an_instance_of(Rack::Headers)
+      expected_class = ENV['RACK_VERSION'] == "2" ? Rack::Utils::HeaderHash : Rack::Headers
+      expect(last_response.headers).to be_an_instance_of(expected_class)
     end
 
     it "parses the headers as a Hash with values of type String" do
@@ -163,7 +164,11 @@ RSpec.describe Rack::ReverseProxy do
 
       headers = last_response.headers.to_hash
       expect(headers["Date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
-      expect(headers["date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
+      if ENV['RACK_VERSION'] == "2"
+        expect(headers["date"]).to be_nil
+      else
+        expect(headers["date"]).to eq("Wed, 22 Jul 2015 11:27:21 GMT")
+      end
     end
 
     it "formats the headers with dashes correctly" do
@@ -175,7 +180,11 @@ RSpec.describe Rack::ReverseProxy do
       get "/2test"
 
       headers = last_response.headers.to_hash
-      expect(headers["x-additional-info"]).to eq("something")
+      if ENV['RACK_VERSION'] == "2"
+        expect(headers["x-additional-info"]).to be_nil
+      else
+        expect(headers["x-additional-info"]).to eq("something")
+      end
     end
 
     it "the response header includes content-length" do

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -767,7 +767,7 @@ RSpec.describe Rack::ReverseProxy do
     end
   end
 
-  describe "as a rack app", skip: true do
+  describe "as a rack app", skip: ENV['RACK_VERSION'] == "2" do
     it "responds with 404 when the path is not matched" do
       get "/"
       expect(last_response).to be_not_found

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -767,7 +767,7 @@ RSpec.describe Rack::ReverseProxy do
     end
   end
 
-  describe "as a rack app" do
+  describe "as a rack app", skip: true do
     it "responds with 404 when the path is not matched" do
       get "/"
       expect(last_response).to be_not_found

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 require "simplecov"
 SimpleCov.start
 
+require "debug"
 require "rack/reverse_proxy"
 require "rack/test"
 require "webmock/rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,4 +103,8 @@ RSpec.configure do |config|
 
   # User-defined configuration
   WebMock.disable_net_connect!
+
+  def rack_version_less_than_three
+    Rack.release.split('.').first.to_i < 3
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 require "simplecov"
 SimpleCov.start
 
-require "debug"
 require "rack/reverse_proxy"
 require "rack/test"
 require "webmock/rspec"


### PR DESCRIPTION
Building on #73 

This PR provides backwards compatibility for Rack 2, preserving the existing behaviour for Rack 2 users, whilst allowing Rack 3 users to still utilise this project.

#73 would fail on earlier versions of Ruby due to the bundler version being updated. We can relax that restriction to allow users on older and newer versions to proceed

![Screenshot 2024-11-29 at 17 37 39](https://github.com/user-attachments/assets/7e558901-8f0e-4a75-a19d-b8040522c914)

Test runs on Ruby 2.7 through to 3.3, with Rack 2 & 3.

![Screenshot 2024-11-29 at 17 39 01](https://github.com/user-attachments/assets/055f5f04-08d7-4dff-8725-e9775af5d19d)

One test is failing with Rack 2, as the code stands in master

```

Failures:

  1) RackReverseProxy::Middleware as a rack app responds with 404 when the path is not matched
     Failure/Error: get "/"

     NoMethodError:
       undefined method `has_key?' for []:Array
     # ./spec/rack/reverse_proxy_spec.rb:764:in `block (3 levels) in <top (required)>'
```

https://github.com/waterlink/rack-reverse-proxy/compare/master...pact-foundation:rack-reverse-proxy:refs/heads/master-ci
